### PR TITLE
Update bower.json - Drop dependencies 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,5 +2,10 @@
   "author": "Lucas Galfaso",
   "name": "angular-dynamic-locale",
   "description": "Angular Dynamic Locale",
-  "version": "0.0.2"
+  "version": "0.0.2",
+  "dependencies": {
+    "angular-mocks-unstable": "~1.1.5",
+    "angular": ">= 1.0.7",
+    "angular-i18n": ">= 1.0.7"
+  }
 }


### PR DESCRIPTION
Hello Lucas,

could you drop dependencies to avoid pulling angular/bower-angular packages, so you could use local automated builds of angular. 
Otherwise bower will pull angular-1.0.7, even if you want to code against angular-1.1.5 for example.

As an example, we use jenkins to build angular as an automated task. but if we use libs, which depends on bowers angular, bower will pull last stable version of githubs amgular/bower-angular package, which is v1.0.7

I have looked into other angular libs and most of them don't have dependencies to angular itself. so it shouldn't be harmful.
