### PR TITLE
Prevent 'use strict' from affecting global scope.

### DIFF
--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -1,3 +1,4 @@
+( function(window) {
 'use strict';
 angular.module('tmh.dynamicLocale', []).provider('tmhDynamicLocale', function() {
 
@@ -136,4 +137,4 @@ angular.module('tmh.dynamicLocale', []).provider('tmhDynamicLocale', function() 
     return $cacheFactory('tmh.dynamicLocales.store');
   }];
 }).run(['tmhDynamicLocale', angular.noop]);
-
+}(window) );


### PR DESCRIPTION
No global "use strict".
