### PR TITLE
Fixing issue #17: Script is loaded on page only once for each locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-dynamic-locale",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A minimal module that adds the ability to dynamically change the locale",
   "license": "MIT License, http://www.opensource.org/licenses/MIT",
   "devDependencies": {

--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -6,7 +6,8 @@ angular.module('tmh.dynamicLocale', []).provider('tmhDynamicLocale', function() 
     localeLocationPattern = 'angular/i18n/angular-locale_{{locale}}.js',
     storageFactory = 'tmhDynamicLocaleStorageCache',
     storage,
-    storeKey = 'tmhDynamicLocale.locale';
+    storeKey = 'tmhDynamicLocale.locale',
+    calledScripts = {};
 
   /**
    * Loads a script asynchronously
@@ -15,6 +16,14 @@ angular.module('tmh.dynamicLocale', []).provider('tmhDynamicLocale', function() 
    @ @param {function) callback A function to be called once the script is loaded
    */
   function loadScript(url, callback) {
+
+    if (calledScripts[url]) {
+      return callback();
+    }
+    else {
+      calledScripts[url] = true;
+    }
+
     var script = document.createElement('script'),
       body = document.getElementsByTagName('body')[0];
 

--- a/test/tmhDynamicLocaleSpec.js
+++ b/test/tmhDynamicLocaleSpec.js
@@ -15,6 +15,24 @@ describe('dynamicLocale', function() {
     }, 'locale not reverted', 2000);
   }));
 
+  it('should only load the script on the page once', inject(function($locale, tmhDynamicLocale) {
+    
+    spyOn(document, 'createElement').andCallThrough();
+
+    runs(function() {
+      tmhDynamicLocale.set('es');
+      tmhDynamicLocale.set('es');
+    });
+
+    waitsFor(function() {
+      return $locale.id === 'es';
+    }, 'locale not updated', 2000);
+
+    runs(function() {
+      expect(document.createElement.callCount).toEqual(1);
+    });
+  }));
+
   it('should (eventually) be able to change the locale', inject(function($locale, tmhDynamicLocale) {
     runs(function() {
       tmhDynamicLocale.set('es');


### PR DESCRIPTION
The solution to https://github.com/lgalfaso/angular-dynamic-locale/issues/17

I set up a cache of locale scripts. If the `loadScript` function has already been called for a certain locale, it skips re-creating the `script` element.

Tests are written that correctly break when you take out the `calledScripts` cache code.
