### PR TITLE
Adding npm commands

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(grunt) {
   //grunt plugins
   grunt.loadNpmTasks('grunt-contrib-clean');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "karma-phantomjs-launcher": "0.1.2",
     "karma-jasmine": "0.1.5"
   },
+  "scripts": {
+      "test": "grunt karma:travis",
+      "postinstall": "bower install"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/lgalfaso/angular-dynamic-locale.git"


### PR DESCRIPTION
These are just some good hygiene points that make it easier for other developers to work with this project.
- Defining `npm test` makes project adhere to the npm standard that some meaningful tests will be run via `npm test`. This makes it easy on CI, and makes it easy for developers to enter the project and not have to dig around in a Gruntfile to figure out which tests they should be running. (I picked `grunt karma:travis` but let me know if something else would be better.)
- Adding a `postinstall` step so `npm install` will do both `npm install` and `bower install` - one less command to remember, and one less thing for people to screw up. (Particularly new people who may not immediately realize that bower is necessary.)
- Adding `'use strict'` at the top of the Gruntfile to adhere to that best practice.

Thanks!
