### PR TITLE
Adding main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "karma-phantomjs-launcher": "0.1.2",
     "karma-jasmine": "0.1.5"
   },
+  "main": "./src/tmhDynamicLocale.js",
   "scripts": {
       "test": "grunt karma:travis",
       "postinstall": "bower install"


### PR DESCRIPTION
The `main` field is a npm convention, and allows this module to be consumed from tools like browserify.
