### PR TITLE
Fix timeout

### DIFF
--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -26,7 +26,7 @@ angular.module('tmh.dynamicLocale', []).provider('tmhDynamicLocale', function() 
         if (script.readyState === 'complete' ||
             script.readyState === 'loaded') {
           script.onreadystatechange = null;
-          $timeout(callback, 30, false);
+          callback();
         }
       };
     } else { // Others


### PR DESCRIPTION
The `$timeout` call breaks because `$timeout` is not defined at that point.

I think it's unnecessary, in any case - I tested this branch in ie9 / windows 7, ie10 / windows 8, and ie11 / windows 8.1 and it worked fine.
