### PR TITLE
Do not bower install with npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "main": "./src/tmhDynamicLocale.js",
   "scripts": {
-      "test": "grunt karma:travis",
-      "postinstall": "bower install"
+      "pretest": "bower install",
+      "test": "grunt karma:travis"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Problem

In many `npm` use cases (e.g., `browserify`) there is no reason to `bower install` since dependencies are brought in via `npm`.  In fact, without `bower` installed and configured, `npm install`ing a dependent of `angular-dynamic-locale` fails (bummer).
### Solution

`bower install` only when running tests for this repo, since that is the only time it's truly needed in the node/npm world.
