### PR TITLE
Remove duplicated body.removeChild call to fix IE breakages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "name": "angular-dynamic-locale",
   "main": "src/tmhDynamicLocale.js",
   "description": "Angular Dynamic Locale",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "devDependencies": {
     "angular-mocks": "1.2.8",
     "angular": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-dynamic-locale",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "A minimal module that adds the ability to dynamically change the locale",
   "license": "MIT License, http://www.opensource.org/licenses/MIT",
   "devDependencies": {

--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -26,7 +26,6 @@ angular.module('tmh.dynamicLocale', []).provider('tmhDynamicLocale', function() 
         if (script.readyState === 'complete' ||
             script.readyState === 'loaded') {
           script.onreadystatechange = null;
-          body.removeChild(script);
           $timeout(
             function () {
               body.removeChild(script);


### PR DESCRIPTION
When you pushed [this commit](https://github.com/lgalfaso/angular-dynamic-locale/commit/ae938f29f025c517923de91b7648e3fe7e1c3fff), you removed the script tag from the page. But for the IE block, you removed the script tag twice. This causes an error in IE 9/10 because we're trying to remove a node that doesn't exist.

It throws the error:

```
DOM Exception: NOT_FOUND_ERR (8)
```

or

```
NotFoundErrorundefined
```

---

I removed one of the `removeChild` calls and verified that this works on IE 9/10.
