### PR TITLE
Include Angular version in interpolate context

### DIFF
--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -223,7 +223,7 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
     };
 
     function loadLocaleFn(localeId) {
-      return loadLocale(localeLocation({locale: localeId, version: angular.version.full}), locale, localeId, $rootScope, $q, tmhDynamicLocaleCache, $timeout);
+      return loadLocale(localeLocation({locale: localeId, angularVersion: angular.version.full}), locale, localeId, $rootScope, $q, tmhDynamicLocaleCache, $timeout);
     }
   }];
 }]).provider('tmhDynamicLocaleCache', function() {

--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -223,7 +223,7 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
     };
 
     function loadLocaleFn(localeId) {
-      return loadLocale(localeLocation({locale: localeId}), locale, localeId, $rootScope, $q, tmhDynamicLocaleCache, $timeout);
+      return loadLocale(localeLocation({locale: localeId, version: angular.version.full}), locale, localeId, $rootScope, $q, tmhDynamicLocaleCache, $timeout);
     }
   }];
 }]).provider('tmhDynamicLocaleCache', function() {


### PR DESCRIPTION
Including the Angular version would allow a `localLocationPattern` like `"https://cdnjs.cloudflare.com/ajax/libs/angular.js/{{version}}/i18n/angular-locale_{{locale}}.js"` for those who wish to use a CDN