### PR TITLE
Make locale script load asynchronously

### DIFF
--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -77,7 +77,7 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
       };
     }
     script.src = url;
-    script.async = false;
+    script.async = true;
     body.appendChild(script);
   }
 


### PR DESCRIPTION
Otherwise, onload event does not fire in certain environments such as in WinJS apps.