### PR TITLE
Allow specifying a custom DOM node element to append the locale script

### DIFF
--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -30,6 +30,7 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
 
   var defaultLocale,
     localeLocationPattern = 'angular/i18n/angular-locale_{{locale}}.js',
+    nodeToAppend,
     storageFactory = 'tmhDynamicLocaleStorageCache',
     storage,
     storageKey = STORAGE_KEY,
@@ -44,7 +45,7 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
    */
   function loadScript(url, callback, errorCallback, $timeout) {
     var script = document.createElement('script'),
-      body = document.getElementsByTagName('body')[0],
+      element = nodeToAppend ? nodeToAppend : document.getElementsByTagName("body")[0],
       removed = false;
 
     script.type = 'text/javascript';
@@ -57,7 +58,7 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
             function () {
               if (removed) return;
               removed = true;
-              body.removeChild(script);
+              element.removeChild(script);
               callback();
             }, 30, false);
         }
@@ -66,19 +67,19 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
       script.onload = function () {
         if (removed) return;
         removed = true;
-        body.removeChild(script);
+        element.removeChild(script);
         callback();
       };
       script.onerror = function () {
         if (removed) return;
         removed = true;
-        body.removeChild(script);
+        element.removeChild(script);
         errorCallback();
       };
     }
     script.src = url;
     script.async = true;
-    body.appendChild(script);
+    element.appendChild(script);
   }
 
   /**
@@ -174,6 +175,10 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
     } else {
       return localeLocationPattern;
     }
+  };
+
+  this.appendScriptTo = function(nodeElement) {
+    nodeToAppend = nodeElement;
   };
 
   this.useStorage = function(storageName) {

--- a/test/tmhDynamicLocaleSpec.js
+++ b/test/tmhDynamicLocaleSpec.js
@@ -575,9 +575,9 @@
     });
 
     describe('loading locales using <script>', function () {
-      function countLocales($document, localeId) {
+      function countLocales(node, localeId) {
         var count = 0,
-          scripts = $document[0].getElementsByTagName('script');
+          scripts = node.getElementsByTagName('script');
 
         for (var i = 0; i < scripts.length; ++i) {
           count += (scripts[i].src === 'http://localhost:9876/base/node_modules/angular-i18n/angular-locale_' + localeId + '.js' ? 1 : 0);
@@ -591,17 +591,33 @@
           job
             .runs(function() {
               tmhDynamicLocale.set('fr');
-              expect(countLocales($document, 'fr')).toBe(1);
+              expect(countLocales($document[0].body, 'fr')).toBe(1);
             })
             .waitsFor(function() {
               $timeout.flush(50);
               return $locale.id === 'fr';
             }, 'locale not updated', 2000)
             .runs(function() {
-              expect(countLocales($document, 'fr')).toBe(0);
+              expect(countLocales($document[0].body, 'fr')).toBe(0);
             })
             .done();
         job.start();
+        });
+      });
+
+      it('should load the locales in the custom tag (head) using a <script> tag', function(done) {
+        module(function(tmhDynamicLocaleProvider) {
+          tmhDynamicLocaleProvider.appendScriptTo(document.head);
+        });
+        
+        inject(function ($timeout, tmhDynamicLocale, $document, $locale) {
+          var job = createAsync(done);
+          job
+          .runs(function() {
+            tmhDynamicLocale.set('fr');
+            expect(countLocales($document[0].head, 'fr')).toBe(1);
+          }).done();
+          job.start();
         });
       });
 
@@ -613,16 +629,16 @@
             .runs(function() {
               tmhDynamicLocale.set('ja');
               tmhDynamicLocale.set('ja');
-              expect(countLocales($document, 'ja')).toBe(1);
+              expect(countLocales($document[0].body, 'ja')).toBe(1);
             })
             .waitsFor(function() {
               $timeout.flush(50);
               return $locale.id === 'ja';
             }, 'locale not updated', 2000)
             .runs(function() {
-              expect(countLocales($document, 'ja')).toBe(0);
+              expect(countLocales($document[0].body, 'ja')).toBe(0);
               tmhDynamicLocale.set('ja');
-              expect(countLocales($document, 'ja')).toBe(0);
+              expect(countLocales($document[0].body, 'ja')).toBe(0);
               tmhDynamicLocale.set('et');
             })
             .waitsFor(function() {
@@ -632,9 +648,9 @@
             .runs(function() {
               $rootScope.$apply(function () {
                 tmhDynamicLocale.set('ja');
-                expect(countLocales($document, 'ja')).toBe(0);
+                expect(countLocales($document[0].body, 'ja')).toBe(0);
               });
-              expect(countLocales($document, 'ja')).toBe(0);
+              expect(countLocales($document[0].body, 'ja')).toBe(0);
             })
             .done();
           job.start();


### PR DESCRIPTION
Allow specifying a custom DOM node element (for example: document.head) to append the locale script, instead of the body tag as default.

Closes #85 