### PR TITLE
Allow to use function for localeLocationPattern

### DIFF
--- a/src/tmhDynamicLocale.js
+++ b/src/tmhDynamicLocale.js
@@ -203,7 +203,7 @@ angular.module('tmh.dynamicLocale', []).config(['$provide', function($provide) {
   };
 
   this.$get = ['$rootScope', '$injector', '$interpolate', '$locale', '$q', 'tmhDynamicLocaleCache', '$timeout', function($rootScope, $injector, interpolate, locale, $q, tmhDynamicLocaleCache, $timeout) {
-    var localeLocation = interpolate(localeLocationPattern);
+    var localeLocation = angular.isFunction(localeLocationPattern) ? localeLocationPattern : interpolate(localeLocationPattern);
 
     storage = $injector.get(storageFactory);
     $rootScope.$evalAsync(function() {


### PR DESCRIPTION
Hello, currently using `filerev` on my code, I need a way to give versioned file urls to `angular-dynamic-locale', for exemple `angular-locale_fr.451dbee7.js`, `/i18n/angular-locale_de.95c5261c.js`

To do so, I propose the following : the ability to use a function to create localeLocation, and then do the following : 
```javascript
app.config(['tmhDynamicLocaleProvider', 'angularLocales', function(tmhDynamicLocaleProvider, angularLocales) {
  tmhDynamicLocaleProvider.localeLocationPattern(function(params) {
    return angularLocales[params.locale];
  });
}])
```

Then define a constant with url per language : 

```javascript
angular.module("angularLocales", [])
  .constant("angularLocales", {
    fr: "/i18n/angular-locale_fr.js",
    de: "/i18n/angular-locale_de.js",
    en: "/i18n/angular-locale_en.js"
});
```

That will be processed by filerev to 

```javascript
angular.module("angularLocales", [])
  .constant("angularLocales", {
    fr: "/i18n/angular-locale_fr.451dbee7.js",
    de: "/i18n/angular-locale_de.95c5261c.js",
    en: "/i18n/angular-locale_en.c47dde3d.js"
});
```

What do you think ? thanks
