### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-dynamic-locale",
   "version": "0.1.32",
   "description": "A minimal module that adds the ability to dynamically change the locale",
-  "license": "MIT License, http://www.opensource.org/licenses/MIT",
+  "license": "MIT",
   "devDependencies": {
     "angular": "1.3.0",
     "angular-cookies": "1.3.0",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)