### PR TITLE
initial tmh.IDynamicLocale

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/lgalfaso/angular-dynamic-locale.git"
+  },
+  "dependencies": {
+    "@types/angular": "^1.6.25"
   }
 }

--- a/src/tmhDynamicLocale.d.ts
+++ b/src/tmhDynamicLocale.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for tmhDynamicLocale
+// Project: http://angularjs.org
+// Definitions by: Gerardo Lima <https://github.com/gerardolima>
+// Definitions: https://github.com/lgalfaso/angular-dynamic-locale
+// TypeScript Version: 2.4.1
+
+import * as ng from 'angular';
+
+export as namespace tmh;
+
+declare namespace tmh
+{
+    interface IDynamicLocale
+    {
+        set(locale: string): ng.IPromise<ng.ILocaleService>;
+        get(): string;
+    }
+}


### PR DESCRIPTION
hi, @lgalfaso, this is a simple type definition for _tmhDynamicLocale_ as _tmh.IDynamicLocale_.

It currently creates the namespace _tmh_ and the interface _IDynamicLocale_, with only two members: _get_ and _set_. I think it's the minimal type definitions to work with typescript.